### PR TITLE
Implement power cap

### DIFF
--- a/src/Ilúvatar/Cargo.toml
+++ b/src/Ilúvatar/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "ilúvatar_worker_library",
   "ilúvatar_energy_mon"
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.2.0"

--- a/src/Ilúvatar/Makefile
+++ b/src/Ilúvatar/Makefile
@@ -9,10 +9,10 @@ clean:
 	@cargo clean
 check:
 	@echo "Checking"
-	@cargo check
+	@cargo check $(cargo_args)
 release:
 	@echo "Building release"
-	@cargo build --release -j $(NPROCS)
+	@cargo build --release -j $(NPROCS) $(cargo_args)
 tiny:
 # https://github.com/johnthagen/min-sized-rust
 	@echo "Building tiny version"
@@ -22,15 +22,15 @@ tiny:
 	@upx --best --lzma ./target/x86_64-unknown-linux-gnu/tiny/ilúvatar_*
 debug:
 	@echo "Building debug"
-	@cargo build -j $(NPROCS)
+	@cargo build -j $(NPROCS) $(cargo_args)
 spans:
 	@echo "Building full_spans"
-	@cargo build --features full_spans --release -j $(NPROCS)
+	@cargo build --features full_spans --release -j $(NPROCS) $(cargo_args)
 spansd:
 	@echo "Building debug full_spans"
-	@cargo build --features full_spans -j $(NPROCS)
+	@cargo build --features full_spans -j $(NPROCS) $(cargo_args)
 flame:
 	@echo "TODO: implement running flame"
 test:
 	@echo "Running unit tests"
-	@cargo test
+	@cargo test $(cargo_args)

--- a/src/Ilúvatar/ansible/worker.yml
+++ b/src/Ilúvatar/ansible/worker.yml
@@ -139,6 +139,7 @@
       "ILUVATAR_WORKER__invocation__cpu__queue_policy" : "{{ worker_cpu_queue_policy | default('fcfs') }}"
       "ILUVATAR_WORKER__invocation__gpu__queue_policy" : "{{ worker_gpu_queue_policy | default('fcfs') }}"
       "ILUVATAR_WORKER__invocation__enqueueing_policy" : "{{ worker_enqueueing | default('All') }}"
+      "ILUVATAR_WORKER__invocation__power_cap" : "{{ worker_power_cap | default(0.0) }}"
       # Status config
       "ILUVATAR_WORKER__status__report_freq_ms" : "{{ worker_status_ms | default(2000) }}"
 

--- a/src/Ilúvatar/ansible/worker.yml
+++ b/src/Ilúvatar/ansible/worker.yml
@@ -127,6 +127,10 @@
       "ILUVATAR_WORKER__energy__ipmi_pass_file" : "{{ worker_ipmi_pass_file | default('') }}"
       "ILUVATAR_WORKER__energy__ipmi_ip_addr" : "{{ worker_ipmi_ip_addr | default(servers[ansible_host].ipmi_ip) }}"
       "ILUVATAR_WORKER__energy__log_folder": "{{ worker_log_dir | default('/tmp/ilúvatar/logs') }}"
+      # Energy cap config
+      "ILUVATAR_WORKER__energy_cap__power_cap" : "{{ worker_power_cap | default(0.0) }}"
+      "ILUVATAR_WORKER__energy_cap__power_cap_version" : "{{ worker_power_cap_version | default('V0') }}"
+
       # Influx config
       "ILUVATAR_WORKER__influx__host" : "{{ influx.address }}"
       "ILUVATAR_WORKER__influx__org" : "{{ influx.organization }}"
@@ -139,7 +143,6 @@
       "ILUVATAR_WORKER__invocation__cpu__queue_policy" : "{{ worker_cpu_queue_policy | default('fcfs') }}"
       "ILUVATAR_WORKER__invocation__gpu__queue_policy" : "{{ worker_gpu_queue_policy | default('fcfs') }}"
       "ILUVATAR_WORKER__invocation__enqueueing_policy" : "{{ worker_enqueueing | default('All') }}"
-      "ILUVATAR_WORKER__invocation__power_cap" : "{{ worker_power_cap | default(0.0) }}"
       # Status config
       "ILUVATAR_WORKER__status__report_freq_ms" : "{{ worker_status_ms | default(2000) }}"
 

--- a/src/Ilúvatar/docs/ENERGY.md
+++ b/src/Ilúvatar/docs/ENERGY.md
@@ -1,0 +1,15 @@
+# Energy Monitoring
+
+
+## Power cap
+
+A power-capping feature has been implemented where the worker monitors system-level usage and can force queue invocations if power usage exceeds a certain limit.
+The code can be found [here](../ilúvatar_worker_library/src/services/invocation/energy_limiter.rs).
+Two policies exist for it that are described in the `PowerCapVersion` enum.
+An energy measuring source, either IPMI or RAPL must also be configured to use this feature at runtime.
+
+This is a compile-time feature, and can be enabled with an argument passed to `make`.
+
+```bash
+make cargo_args='--features "power_cap"'
+```

--- a/src/Ilúvatar/docs/examples/benchmark/run.sh
+++ b/src/Ilúvatar/docs/examples/benchmark/run.sh
@@ -7,8 +7,8 @@ MEMORY=4096
 results_dir="."
 worker_log_dir="/tmp/ilúvatar/logs/ansible"
 environment='local'
-hosts="-e @../../../ansible/group_vars/local_addresses.yml"
-host_file="../../../ansible/environments/$environment/hosts.ini"
+hosts="-e @$ILU_HOME/ansible/group_vars/local_addresses.yml"
+host_file="$ILU_HOME/ansible/environments/$environment/hosts.ini"
 host="127.0.0.1"
 log_file="$results_dir/orchestration.log"
 

--- a/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
+++ b/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
@@ -14,6 +14,7 @@ pub struct EnergyLogger {
   proc: Option<Arc<ProcessMonitor>>,
   _perf_child: Option<std::process::Child>,
   cpu: Option<Arc<CpuFreqMonitor>>,
+  config: Option<Arc<EnergyConfig>>
 }
 
 impl EnergyLogger {
@@ -77,8 +78,25 @@ impl EnergyLogger {
     };
 
     Ok(Arc::new(EnergyLogger {
-      rapl, ipmi, proc, _perf_child: perf_child, cpu
+      rapl, ipmi, proc, _perf_child: perf_child, cpu,
+      config: config.cloned(),
     }))
+  }
+
+  pub fn get_reading_time_ms(&self) -> u64 {
+    if let Some(c) = &self.config {
+      if let Some(ms) = c.ipmi_freq_ms {
+        return ms;
+      }
+      if let Some(ms) = c.rapl_freq_ms {
+        return ms;
+      }
+    }
+    0
+  }
+
+  pub fn readings_enabled(&self) -> bool {
+    return self.ipmi.is_some() || self.rapl.is_some()
   }
 
   pub fn get_latest_reading(&self) -> (i128, f64) {

--- a/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
+++ b/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
@@ -86,10 +86,14 @@ impl EnergyLogger {
   pub fn get_reading_time_ms(&self) -> u64 {
     if let Some(c) = &self.config {
       if let Some(ms) = c.ipmi_freq_ms {
-        return ms;
+        if ms > 0 {
+          return ms;
+        }
       }
       if let Some(ms) = c.rapl_freq_ms {
-        return ms;
+        if ms > 0 {
+          return ms;
+        }
       }
     }
     0
@@ -99,6 +103,7 @@ impl EnergyLogger {
     return self.ipmi.is_some() || self.rapl.is_some()
   }
 
+  /// Return the latest energy reading in (timestamp_ns, Joules)
   pub fn get_latest_reading(&self) -> (i128, f64) {
     if let Some(ipmi) = &self.ipmi {
       return ipmi.get_latest_reading();

--- a/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
+++ b/src/Ilúvatar/ilúvatar_library/src/energy/energy_logging.rs
@@ -80,6 +80,16 @@ impl EnergyLogger {
       rapl, ipmi, proc, _perf_child: perf_child, cpu
     }))
   }
+
+  pub fn get_latest_reading(&self) -> (i128, f64) {
+    if let Some(ipmi) = &self.ipmi {
+      return ipmi.get_latest_reading();
+    }
+    if let Some(rapl) = &self.rapl {
+      return rapl.get_latest_reading();
+    }
+    (0,0.0)
+  }
 }
 
 impl Drop for EnergyLogger {

--- a/src/Ilúvatar/ilúvatar_library/src/energy/ipmi.rs
+++ b/src/Ilúvatar/ilúvatar_library/src/energy/ipmi.rs
@@ -82,6 +82,7 @@ impl IPMIMonitor {
     Ok(r)
   }
 
+  /// Return the latest energy reading in (timestamp_ns, Joules)
   pub fn get_latest_reading(&self) -> (i128, f64) {
     return *self.latest_reading.read()
   }

--- a/src/Ilúvatar/ilúvatar_library/src/energy/ipmi.rs
+++ b/src/Ilúvatar/ilúvatar_library/src/energy/ipmi.rs
@@ -98,7 +98,7 @@ impl IPMIMonitor {
       },
     };
     let now = self.timer.now();
-    *self.latest_reading.write() = (now.unix_timestamp_nanos(), ipmi_uj as f64 / 1_000_000.0);
+    *self.latest_reading.write() = (now.unix_timestamp_nanos(), ipmi_uj as f64);
     let t = match self.timer.format_time(now) {
       Ok(t) => t,
       Err(e) => {

--- a/src/Ilúvatar/ilúvatar_worker/src/worker.json
+++ b/src/Ilúvatar/ilúvatar_worker/src/worker.json
@@ -24,7 +24,8 @@
     "queue_policies": {
       "cpu": "fcfs",
       "gpu": "fcfs"
-    }
+    },
+    "power_cap": 0.0
   },
   "logging": {
     "level": "info",

--- a/src/Ilúvatar/ilúvatar_worker_library/Cargo.toml
+++ b/src/Ilúvatar/ilúvatar_worker_library/Cargo.toml
@@ -56,3 +56,4 @@ rand = "0.8"
 
 [features]
 full_spans = []
+power_cap = []

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/cpu_q_invoke.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/cpu_q_invoke.rs
@@ -153,9 +153,12 @@ impl CpuQueueingInvoker {
   /// Returns an owned permit if there are sufficient resources to run a function
   /// A return value of [None] means the resources failed to be acquired
   fn acquire_resources_to_run(&self, item: &Arc<EnqueuedInvocation>) -> Option<Box<dyn Drop+Send>> {
+    debug!(tid=%item.tid, "checking resources");
     if ! self.energy.ok_run_fn(&self.cmap, &item.registration.fqdn) {
+      debug!(tid=%item.tid, "Blocking invocation due to power overload");
       return None
     }
+    debug!(tid=%item.tid, "energy cap OK");
     let mut ret = vec![];
     match self.cpu.try_acquire_cores(&item.registration, &item.tid) {
       Ok(c) => ret.push(c),

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
@@ -4,7 +4,7 @@ use iluvatar_library::energy::energy_logging::EnergyLogger;
 use crate::worker_api::config::InvocationConfig;
 use anyhow::Result;
 
-const POWCAP_MIN: f64 = 1.0;
+const POWCAP_MIN: f64 = 0.0;
 pub struct EnergyLimiter {
     powcap: f64,
     energy: Arc<EnergyLogger>,
@@ -29,7 +29,7 @@ impl EnergyLimiter {
     fn get_energy(&self, cmap: &Arc<CharacteristicsMap>, fqdn: &String, power: f64) -> f64 {
         let exec_time = cmap.get_exec_time(fqdn);
         let j = exec_time * power;
-        tracing::debug!("get energy {} {} {}", exec_time, power, j);
+        tracing::debug!("get energy exec_time({}) * power){}) = j({})", exec_time, power, j);
         return j;
     }
 
@@ -45,7 +45,7 @@ impl EnergyLimiter {
         let j_predicted = p * self.reading_freq_sec;
         let j_cap = self.powcap * self.reading_freq_sec;
 
-        tracing::debug!(fname=%fname, "power cap check p:{}; j_predicted({}) + j({})  <= j_cap({})", p, j_predicted, j, j_cap);
+        tracing::debug!(fname=%fname, "power cap check j_predicted(p({}) * freq({})) + j({})  <= j_cap({})", p, self.reading_freq_sec, j, j_cap);
         return j_predicted + j <= j_cap;
     }
 

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
@@ -2,41 +2,50 @@ use std::sync::Arc;
 use iluvatar_library::characteristics_map::CharacteristicsMap;
 use iluvatar_library::energy::energy_logging::EnergyLogger;
 use crate::worker_api::config::InvocationConfig;
+use anyhow::Result;
 
+const POWCAP_MIN: f64 = 1.0;
 pub struct EnergyLimiter {
     powcap: f64,
     energy: Arc<EnergyLogger>,
+    reading_freq_sec: f64,
 }
-
 impl EnergyLimiter {
-    pub fn boxed(config: &Arc<InvocationConfig>, energy: Arc<EnergyLogger>) -> Arc<Self> {
-        Arc::new(Self {
-            powcap: config.power_cap.map_or(0.0, |v| v),
-            energy,
-        })
+    pub fn boxed(config: &Arc<InvocationConfig>, energy: Arc<EnergyLogger>) -> Result<Arc<Self>> {
+        let powcap = config.power_cap.map_or(0.0, |v| v);
+        if !energy.readings_enabled() && powcap > POWCAP_MIN {
+            anyhow::bail!("'power_cap set but not energy reading source available");
+        }
+        let reading_freq_sec = energy.get_reading_time_ms() as f64 / 1000.0;
+        Ok(Arc::new(Self {
+            powcap, energy, reading_freq_sec
+        }))
     }
 
     fn powcap_enabled(&self) -> bool {
-        return self.powcap > 1.0;
+        return self.powcap > POWCAP_MIN;
     }
 
     fn get_energy(&self, cmap: &Arc<CharacteristicsMap>, fqdn: &String, power: f64) -> f64 {
         let exec_time = cmap.get_exec_time(fqdn);
         let j = exec_time * power;
+        tracing::debug!("get energy {} {} {}", exec_time, power, j);
         return j;
     }
 
     pub fn ok_run_fn(&self, cmap: &Arc<CharacteristicsMap>, fname: &String) -> bool {
         if ! self.powcap_enabled() {
+            tracing::debug!(fname=%fname, "power cap disabled");
             return true;
         }
+        tracing::debug!(fname=%fname, "power cap enabled");
 
         let (_t, p) = self.energy.get_latest_reading();
         let j = self.get_energy(cmap, fname, p);
-        let s = 10.0; //seconds
-        let j_predicted = p*s;
-        let j_cap = self.powcap*s;
+        let j_predicted = p * self.reading_freq_sec;
+        let j_cap = self.powcap * self.reading_freq_sec;
 
+        tracing::debug!(fname=%fname, "power cap check p:{}; j_predicted({}) + j({})  <= j_cap({})", p, j_predicted, j, j_cap);
         return j_predicted + j <= j_cap;
     }
 

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
@@ -5,7 +5,9 @@ use anyhow::Result;
 
 #[derive(Debug, serde::Deserialize, Clone)]
 pub enum PowerCapVersion {
+  /// Check if power usage is under limit to allow invocation
   V0,
+  /// Predict energy usage of invocation in addition to checking current power usage
   V1
 }
 

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/energy_limiter.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+use iluvatar_library::characteristics_map::CharacteristicsMap;
+use iluvatar_library::energy::energy_logging::EnergyLogger;
+use crate::worker_api::config::InvocationConfig;
+
+pub struct EnergyLimiter {
+    powcap: f64,
+    energy: Arc<EnergyLogger>,
+}
+
+impl EnergyLimiter {
+    pub fn boxed(config: &Arc<InvocationConfig>, energy: Arc<EnergyLogger>) -> Arc<Self> {
+        Arc::new(Self {
+            powcap: config.power_cap.map_or(0.0, |v| v),
+            energy,
+        })
+    }
+
+    fn powcap_enabled(&self) -> bool {
+        return self.powcap > 1.0;
+    }
+
+    fn get_energy(&self, cmap: &Arc<CharacteristicsMap>, fqdn: &String, power: f64) -> f64 {
+        let exec_time = cmap.get_exec_time(fqdn);
+        let j = exec_time * power;
+        return j;
+    }
+
+    pub fn ok_run_fn(&self, cmap: &Arc<CharacteristicsMap>, fname: &String) -> bool {
+        if ! self.powcap_enabled() {
+            return true;
+        }
+
+        let (_t, p) = self.energy.get_latest_reading();
+        let j = self.get_energy(cmap, fname, p);
+        let s = 10.0; //seconds
+        let j_predicted = p*s;
+        let j_cap = self.powcap*s;
+
+        return j_predicted + j <= j_cap;
+    }
+
+    pub fn add_pending(&self, _j:f64) {
+        todo!();
+    }
+
+    pub fn sub_pending(&self, _j:f64) {
+        todo!();
+    }
+
+    pub fn add_outgoing(&self, _j:f64) {
+        todo!();
+    }
+
+    pub fn total_outgoing(&self) {
+        todo!();
+    }
+}

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/mod.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/mod.rs
@@ -7,6 +7,7 @@ use std::{sync::Arc, time::Duration};
 use iluvatar_library::{characteristics_map::CharacteristicsMap, transaction::TransactionId, types::Compute};
 use parking_lot::Mutex;
 use crate::services::{containers::structs::{ParsedResult, ContainerState}, registration::RegisteredFunction};
+#[cfg(feature="power_cap")]
 use crate::services::invocation::energy_limiter::EnergyLimiter;
 
 pub mod queueing;
@@ -15,6 +16,7 @@ mod queueing_dispatcher;
 mod gpu_q_invoke;
 mod cpu_q_invoke;
 mod completion_time_tracker;
+#[cfg(feature="power_cap")]
 pub mod energy_limiter;
 
 #[tonic::async_trait]
@@ -44,13 +46,14 @@ pub struct InvokerFactory {
   cmap: Arc<CharacteristicsMap>,
   cpu: Arc<CpuResourceTracker>,
   gpu_resources: Arc<GpuResourceTracker>,
-  energy: Arc<EnergyLimiter>,
+  #[cfg(feature="power_cap")] energy: Arc<EnergyLimiter>,
 }
 
 impl InvokerFactory {
   pub fn new(cont_manager: Arc<ContainerManager>, function_config: Arc<FunctionLimits>,
     invocation_config: Arc<InvocationConfig>, cmap: Arc<CharacteristicsMap>, cpu: Arc<CpuResourceTracker>,
-    gpu_resources: Arc<GpuResourceTracker>, energy: Arc<EnergyLimiter>) -> Self {
+    gpu_resources: Arc<GpuResourceTracker>,
+    #[cfg(feature="power_cap")] energy: Arc<EnergyLimiter>) -> Self {
 
     InvokerFactory {
       cont_manager,
@@ -59,7 +62,7 @@ impl InvokerFactory {
       cmap,
       cpu,
       gpu_resources,
-      energy,
+      #[cfg(feature="power_cap")] energy,
     }
   }
 
@@ -67,7 +70,7 @@ impl InvokerFactory {
     let invoker = QueueingDispatcher::new(self.cont_manager.clone(),
                self.function_config.clone(), self.invocation_config.clone(),
                             tid, self.cmap.clone(), self.cpu.clone(), self.gpu_resources.clone(),
-                            self.energy.clone())?;
+                            #[cfg(feature="power_cap")] self.energy.clone())?;
     Ok(invoker)
   }
 }

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/mod.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/mod.rs
@@ -7,6 +7,7 @@ use std::{sync::Arc, time::Duration};
 use iluvatar_library::{characteristics_map::CharacteristicsMap, transaction::TransactionId, types::Compute};
 use parking_lot::Mutex;
 use crate::services::{containers::structs::{ParsedResult, ContainerState}, registration::RegisteredFunction};
+use crate::services::invocation::energy_limiter::EnergyLimiter;
 
 pub mod queueing;
 pub mod async_tracker;
@@ -14,6 +15,7 @@ mod queueing_dispatcher;
 mod gpu_q_invoke;
 mod cpu_q_invoke;
 mod completion_time_tracker;
+pub mod energy_limiter;
 
 #[tonic::async_trait]
 /// A trait representing the functionality a queue policy must implement
@@ -42,12 +44,13 @@ pub struct InvokerFactory {
   cmap: Arc<CharacteristicsMap>,
   cpu: Arc<CpuResourceTracker>,
   gpu_resources: Arc<GpuResourceTracker>,
+  energy: Arc<EnergyLimiter>,
 }
 
 impl InvokerFactory {
   pub fn new(cont_manager: Arc<ContainerManager>, function_config: Arc<FunctionLimits>,
     invocation_config: Arc<InvocationConfig>, cmap: Arc<CharacteristicsMap>, cpu: Arc<CpuResourceTracker>,
-    gpu_resources: Arc<GpuResourceTracker>) -> Self {
+    gpu_resources: Arc<GpuResourceTracker>, energy: Arc<EnergyLimiter>) -> Self {
 
     InvokerFactory {
       cont_manager,
@@ -56,11 +59,15 @@ impl InvokerFactory {
       cmap,
       cpu,
       gpu_resources,
+      energy,
     }
   }
 
   pub fn get_invoker_service(&self, tid: &TransactionId) -> Result<Arc<dyn Invoker>> {
-    let invoker = QueueingDispatcher::new(self.cont_manager.clone(), self.function_config.clone(), self.invocation_config.clone(), tid, self.cmap.clone(), self.cpu.clone(), self.gpu_resources.clone())?;
+    let invoker = QueueingDispatcher::new(self.cont_manager.clone(),
+               self.function_config.clone(), self.invocation_config.clone(),
+                            tid, self.cmap.clone(), self.cpu.clone(), self.gpu_resources.clone(),
+                            self.energy.clone())?;
     Ok(invoker)
   }
 }

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/queueing_dispatcher.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/invocation/queueing_dispatcher.rs
@@ -7,6 +7,7 @@ use iluvatar_library::characteristics_map::CharacteristicsMap;
 use iluvatar_library::{transaction::TransactionId, logging::LocalTime, types::Compute};
 use tracing::{debug, info};
 use anyhow::Result;
+#[cfg(feature="power_cap")]
 use crate::services::invocation::energy_limiter::EnergyLimiter;
 use super::queueing::{DeviceQueue, EnqueuedInvocation};
 use super::{async_tracker::AsyncHelper, Invoker, InvocationResultPtr, cpu_q_invoke::CpuQueueingInvoker, gpu_q_invoke::GpuQueueingInvoker};
@@ -31,9 +32,11 @@ pub struct QueueingDispatcher {
 impl QueueingDispatcher {
   pub fn new(cont_manager: Arc<ContainerManager>, function_config: Arc<FunctionLimits>, invocation_config: Arc<InvocationConfig>, 
       tid: &TransactionId, cmap: Arc<CharacteristicsMap>, cpu: Arc<CpuResourceTracker>, gpu: Arc<GpuResourceTracker>,
-             energy: Arc<EnergyLimiter>) -> Result<Arc<Self>> {
+             #[cfg(feature="power_cap")]energy: Arc<EnergyLimiter>) -> Result<Arc<Self>> {
     let svc = Arc::new(QueueingDispatcher {
-      cpu_queue: Self::get_invoker_queue(&invocation_config, &cmap, &cont_manager, tid, &function_config, &cpu, & energy)?,
+      cpu_queue: Self::get_invoker_queue(&invocation_config, &cmap,
+                                         &cont_manager, tid, &function_config, &cpu,
+                                         #[cfg(feature="power_cap")] &energy)?,
       gpu_queue: Self::get_invoker_gpu_queue(&invocation_config, &cmap, &cont_manager, tid, &function_config, &cpu, &gpu)?,
       async_functions: AsyncHelper::new(),
       clock: LocalTime::new(tid)?,
@@ -44,14 +47,18 @@ impl QueueingDispatcher {
   }
 
   fn get_invoker_queue(invocation_config: &Arc<InvocationConfig>, cmap: &Arc<CharacteristicsMap>, cont_manager: &Arc<ContainerManager>, 
-      tid: &TransactionId, function_config: &Arc<FunctionLimits>, cpu: &Arc<CpuResourceTracker>, energy: &Arc<EnergyLimiter>)  -> Result<Arc<dyn DeviceQueue>> {
+      tid: &TransactionId, function_config: &Arc<FunctionLimits>, cpu: &Arc<CpuResourceTracker>,
+      #[cfg(feature="power_cap")]energy: &Arc<EnergyLimiter>)  -> Result<Arc<dyn DeviceQueue>> {
     Ok(CpuQueueingInvoker::new(cont_manager.clone(), function_config.clone(),
-                               invocation_config.clone(), tid, cmap.clone(), cpu.clone(), energy.clone())?)
+                               invocation_config.clone(), tid,
+                               cmap.clone(), cpu.clone(),
+                               #[cfg(feature="power_cap")] energy.clone())?)
   }
 
   fn get_invoker_gpu_queue(invocation_config: &Arc<InvocationConfig>, cmap: &Arc<CharacteristicsMap>, cont_manager: &Arc<ContainerManager>, 
      tid: &TransactionId, function_config: &Arc<FunctionLimits>, cpu: &Arc<CpuResourceTracker>, gpu: &Arc<GpuResourceTracker>)  -> Result<Arc<dyn DeviceQueue>> {
-    Ok(GpuQueueingInvoker::new(cont_manager.clone(), function_config.clone(), invocation_config.clone(), tid, cmap.clone(), cpu.clone(), gpu.clone())?)
+    Ok(GpuQueueingInvoker::new(cont_manager.clone(), function_config.clone(),
+                               invocation_config.clone(), tid, cmap.clone(), cpu.clone(), gpu.clone())?)
   }
 
   /// Forms invocation data into a [EnqueuedInvocation] that is returned

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/resources/gpu.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/resources/gpu.rs
@@ -3,7 +3,7 @@ use iluvatar_library::{utils::{execute_cmd, execute_cmd_checked}, transaction::T
 use parking_lot::RwLock;
 use anyhow::Result;
 use tokio::sync::{Semaphore, OwnedSemaphorePermit};
-use tracing::{warn, debug, info};
+use tracing::{warn, debug, info, trace};
 use crate::worker_api::worker_config::ContainerResourceConfig;
 
 #[derive(Debug,serde::Deserialize, serde::Serialize)]
@@ -113,7 +113,7 @@ impl GpuResourceTracker {
   pub fn gpu_utilization(&self, tid: &TransactionId) -> Result<Vec<GpuStatus>> {
     let mut ret: Vec<GpuStatus> = vec![];
     if !std::path:: Path::new("/usr/bin/nvidia-smi").exists() {
-      debug!(tid=%tid, "nvidia-smi not found, not checking GPU utilization");
+      trace!(tid=%tid, "nvidia-smi not found, not checking GPU utilization");
       return Ok(ret);
     }
     let args = vec!["--query-gpu=gpu_uuid,pstate,memory.total,memory.used,utilization.gpu,utilization.memory,power.draw,power.limit", "--format=csv,noheader,nounits"];

--- a/src/Ilúvatar/ilúvatar_worker_library/src/services/resources/gpu.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/services/resources/gpu.rs
@@ -3,7 +3,7 @@ use iluvatar_library::{utils::{execute_cmd, execute_cmd_checked}, transaction::T
 use parking_lot::RwLock;
 use anyhow::Result;
 use tokio::sync::{Semaphore, OwnedSemaphorePermit};
-use tracing::{warn, debug, info, trace};
+use tracing::{warn, info, trace};
 use crate::worker_api::worker_config::ContainerResourceConfig;
 
 #[derive(Debug,serde::Deserialize, serde::Serialize)]

--- a/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/mod.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/mod.rs
@@ -40,7 +40,7 @@ pub async fn create_worker(worker_config: WorkerConfig, tid: &TransactionId) -> 
 
   let energy = EnergyLogger::boxed(worker_config.energy.as_ref(), tid).await
       .or_else(|e| bail_error!(tid=%tid, error=%e, "Failed to make energy logger"))?;
-  let energy_limit = EnergyLimiter::boxed(&worker_config.invocation, energy.clone())
+  let energy_limit = EnergyLimiter::boxed(&worker_config.energy_cap, energy.clone())
       .or_else(|e| bail_error!(tid=%tid, error=%e, "Failed to make worker energy limiter"))?;
 
   let invoker_fact = InvokerFactory::new(container_man.clone(), worker_config.limits.clone(),

--- a/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
@@ -31,18 +31,19 @@ pub struct Configuration {
   /// Optional because energy monitoring is not required
   pub energy: Option<Arc<EnergyConfig>>,
   pub invocation: Arc<InvocationConfig>,
-  /// Energy cap disabled if not pesent
+  /// Energy cap disabled if not present
+  #[cfg(feature="power_cap")]
   pub energy_cap: Option<Arc<crate::services::invocation::energy_limiter::EnergyCapConfig>>,
   pub status: Arc<StatusConfig>,
   pub influx: Option<Arc<InfluxConfig>>,
 }
 
 #[derive(Debug, Deserialize)]
-/// total resources the worker is allowed to allocate to conainers
+/// total resources the worker is allowed to allocate to containers
 pub struct ContainerResourceConfig {
   /// total memory pool in MB
   pub memory_mb: MemSizeMb,
-  /// eviciton algorithm to use
+  /// eviction algorithm to use
   pub eviction: String,
   /// timeout on container startup before error
   pub startup_timeout_ms: u64,
@@ -56,7 +57,7 @@ pub struct ContainerResourceConfig {
   pub snapshotter: String,
   /// The max number of containers allowed to be created concurrently
   ///   Calls to containerd can become extremely delayed if too many happen at once, ~10 
-  ///   If 0 then the concurreny is unlimited
+  ///   If 0 then the concurrency is unlimited
   pub concurrent_creation: u32,
 
   /// Settings for the different compute resources the worker can use

--- a/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
@@ -31,6 +31,8 @@ pub struct Configuration {
   /// Optional because energy monitoring is not required
   pub energy: Option<Arc<EnergyConfig>>,
   pub invocation: Arc<InvocationConfig>,
+  /// Energy cap disabled if not pesent
+  pub energy_cap: Option<Arc<crate::services::invocation::energy_limiter::EnergyCapConfig>>,
   pub status: Arc<StatusConfig>,
   pub influx: Option<Arc<InfluxConfig>>,
 }
@@ -107,9 +109,6 @@ pub struct InvocationConfig {
   /// If present and not zero, invocations with an execution duration less than this
   ///   will bypass concurrency restrictions and be run immediately
   pub bypass_duration_ms: Option<u64>,
-  /// Maximum power usage before pausing invocations to wait for power drop
-  /// Disabled if not present or < 1.0
-  pub power_cap: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
+++ b/src/Ilúvatar/ilúvatar_worker_library/src/worker_api/worker_config.rs
@@ -107,6 +107,9 @@ pub struct InvocationConfig {
   /// If present and not zero, invocations with an execution duration less than this
   ///   will bypass concurrency restrictions and be run immediately
   pub bypass_duration_ms: Option<u64>,
+  /// Maximum power usage before pausing invocations to wait for power drop
+  /// Disabled if not present or < 1.0
+  pub power_cap: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/load/analysis/parse_logs.py
+++ b/src/load/analysis/parse_logs.py
@@ -127,19 +127,21 @@ def prepare_energy_log(df: pd.DataFrame) -> pd.DataFrame:
             continue
         data["cpu_pct"] = int(json_log["cpu_sy"]) + int(json_log["cpu_us"]) + int(json_log["cpu_wa"])
 
-        data["hw_cpu_hz_mean"] = np.mean(json_log["hardware_cpu_freqs"])
-        data["hw_cpu_hz_max"] = np.min(json_log["hardware_cpu_freqs"])
-        data["hw_cpu_hz_min"] = np.max(json_log["hardware_cpu_freqs"])
-        data["hw_cpu_hz_std"] = np.std(json_log["hardware_cpu_freqs"])
-        for cpu in range(len(json_log["hardware_cpu_freqs"])):
-          data["hw_cpu{}_hz".format(cpu)] = json_log["hardware_cpu_freqs"][cpu]
+        if "hardware_cpu_freqs" in json_log:
+          data["hw_cpu_hz_mean"] = np.mean(json_log["hardware_cpu_freqs"])
+          data["hw_cpu_hz_max"] = np.min(json_log["hardware_cpu_freqs"])
+          data["hw_cpu_hz_min"] = np.max(json_log["hardware_cpu_freqs"])
+          data["hw_cpu_hz_std"] = np.std(json_log["hardware_cpu_freqs"])
+          for cpu in range(len(json_log["hardware_cpu_freqs"])):
+            data["hw_cpu{}_hz".format(cpu)] = json_log["hardware_cpu_freqs"][cpu]
 
-        data["kern_cpu_hz_mean"] = np.mean(json_log["kernel_cpu_freqs"])
-        data["kern_cpu_hz_max"] = np.min(json_log["kernel_cpu_freqs"])
-        data["kern_cpu_hz_min"] = np.max(json_log["kernel_cpu_freqs"])
-        data["kern_cpu_hz_std"] = np.std(json_log["kernel_cpu_freqs"])
-        for cpu in range(len(json_log["kernel_cpu_freqs"])):
-          data["kern_cpu{}_hz".format(cpu)] = json_log["kernel_cpu_freqs"][cpu]
+        if "kernel_cpu_freqs" in json_log:
+          data["kern_cpu_hz_mean"] = np.mean(json_log["kernel_cpu_freqs"])
+          data["kern_cpu_hz_max"] = np.min(json_log["kernel_cpu_freqs"])
+          data["kern_cpu_hz_min"] = np.max(json_log["kernel_cpu_freqs"])
+          data["kern_cpu_hz_std"] = np.std(json_log["kernel_cpu_freqs"])
+          for cpu in range(len(json_log["kernel_cpu_freqs"])):
+            data["kern_cpu{}_hz".format(cpu)] = json_log["kernel_cpu_freqs"][cpu]
         cpu_data.append(data)
 
   cpu_df = pd.DataFrame.from_records(cpu_data)

--- a/src/load/analysis/plot_predict.py
+++ b/src/load/analysis/plot_predict.py
@@ -14,16 +14,32 @@ mpl.rcParams['ps.fonttype'] = 42
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import json
+from dateutil.parser import isoparse
+from dateutil import tz
 
 """
 Sanitize and make consistent the various log files output by the worker or energy monitor
 """
+def timestamp_to_pddate( time ):
+  try:
+      return pd.to_datetime( time )
+  except:
+      ptime = pd.to_datetime( time, format="%Y-%m-%d %H:%M:%S:%f+" )
+      ptime = ptime.replace(tzinfo=tz.tzutc())
+      local = ptime.astimezone(tz.tzlocal())
+      local = local.replace(tzinfo=None)
+      return local
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument("--log-file", '-l', help="log file location", required=True, type=str)
 argparser.add_argument("--power-cap", '-p', help="power cap level", required=True, type=float)
-argparser.add_argument("--rapl-file", '-r', help="Rapl file location", required=True, type=str)
+argparser.add_argument("--rapl-file", '-r', help="Rapl file location", required=False, type=str)
+argparser.add_argument("--ipmi-file", '-i', help="IPMI file location", required=False, type=str)
 args = argparser.parse_args()
+
+if not ((args.ipmi_file is None) ^ (args.rapl_file is None)):
+  print("Must have either IPMI or RAPL file!")
+  exit(1)
 
 data = []
 for line in open(args.log_file).readlines():
@@ -32,7 +48,7 @@ for line in open(args.log_file).readlines():
         if "power cap check" in parsed["fields"]["message"]:
             parts = parsed["fields"]["message"].split(' ')
             power = expec_func_usage = None
-            timestamp = parts[0]
+            timestamp = timestamp_to_pddate(parsed["timestamp"])
             for p in parts:
                 if p.startswith("j("):
                     expec_func_usage = float(p[len("j("):-1])
@@ -44,28 +60,39 @@ for line in open(args.log_file).readlines():
 
 cols = ["timestamp", "energy", "predicted"]
 df = pd.DataFrame.from_records(data, columns=cols)
-print(df.describe())
+# print(df.describe())
 
+if args.ipmi_file is not None:
+  cols = ["timestamp", "ipmi"]
+  df2 = pd.read_csv(args.ipmi_file, skiprows=1, names=cols)
+  df2["energy"] = df2["ipmi"]
+  df2["timestamp"] = df2["timestamp"].apply(timestamp_to_pddate)
+elif args.rapl_file is None:
+  cols = ["timestamp", "rapl_uj", "rapl_uj_diff"]
+  df2 = pd.read_csv(args.rapl_file, skiprows=1, names=cols)
+  df2 = df2[df2["rapl_uj_diff"] < 1000000]
+  df2["energy"] = df2["rapl_uj_diff"] / 1_000_000.0
 
-cols = ["timestamp", "rapl_uj", "rapl_uj_diff"]
-df2 = pd.read_csv(args.rapl_file, skiprows=1, names=cols)
-df2 = df2[df2["rapl_uj_diff"] < 1000000]
+print(df2["timestamp"])
+print(df["timestamp"])
+df2 = df2[df2["timestamp"] < df["timestamp"].max()]
+df2 = df2[df2["timestamp"] > df["timestamp"].min()]
 
 fig, ax = plt.subplots()
 plt.tight_layout()
 fig.set_size_inches(5, 3)
 
-ax.plot(df["predicted"], color='blue', label="predicted")
-ax.plot(df["energy"], color='green', label="power reading (j)")
-ax.plot(df["energy"] + df["predicted"], color='red', label="j_predicted + j")
-ax.plot(df2["rapl_uj_diff"] / 1_000_000.0, color='orange', label="rapl_uj_diff")
+ax.plot(df["timestamp"], df["predicted"], color='blue', label="predicted")
+ax.plot(df["timestamp"], df["energy"], color='green', label="power reading (j)")
+ax.plot(df["timestamp"], df["energy"] + df["predicted"], color='red', label="j_predicted + j")
+ax.plot(df2["timestamp"], df2["energy"], color='orange', label="System Energy")
 
 ax.axhline(args.power_cap, color='black', label="power cap")
 
 # ax.set_title("Energy Cap")
 ax.set_ylabel("Joules")
 # ax.set_xlabel("Time (sec)")
-ax.legend()
+ax.legend(loc=(1,0))
 save_fname = os.path.join(os.path.dirname(args.log_file), "predict.png")
 plt.savefig(save_fname, bbox_inches="tight")
 plt.close(fig)

--- a/src/load/analysis/plot_predict.py
+++ b/src/load/analysis/plot_predict.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+from string import whitespace
+import pandas as pd
+import numpy as np
+from dateutil.parser import isoparse
+import json
+from datetime import datetime, timedelta, timezone
+import matplotlib as mpl
+import matplotlib.patches as mpatches
+mpl.rcParams.update({'font.size': 14})
+mpl.rcParams['pdf.fonttype'] = 42
+mpl.rcParams['ps.fonttype'] = 42
+mpl.use('Agg')
+import matplotlib.pyplot as plt
+import json
+
+"""
+Sanitize and make consistent the various log files output by the worker or energy monitor
+"""
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("--log-file", '-l', help="log file location", required=True, type=str)
+argparser.add_argument("--power-cap", '-p', help="power cap level", required=True, type=float)
+argparser.add_argument("--rapl-file", '-r', help="Rapl file location", required=True, type=str)
+args = argparser.parse_args()
+
+data = []
+for line in open(args.log_file).readlines():
+    parsed = json.loads(line)
+    if "fields" in parsed and "message" in parsed["fields"]:
+        if "power cap check" in parsed["fields"]["message"]:
+            parts = parsed["fields"]["message"].split(' ')
+            power = expec_func_usage = None
+            timestamp = parts[0]
+            for p in parts:
+                if p.startswith("j("):
+                    expec_func_usage = float(p[len("j("):-1])
+                if p.startswith("j_predicted(p("):
+                    power = float(p[len("j_predicted(p("):-1])
+
+            if power is not None and expec_func_usage is not None:
+                data.append((timestamp, power, expec_func_usage))
+
+cols = ["timestamp", "energy", "predicted"]
+df = pd.DataFrame.from_records(data, columns=cols)
+print(df.describe())
+
+
+cols = ["timestamp", "rapl_uj", "rapl_uj_diff"]
+df2 = pd.read_csv(args.rapl_file, skiprows=1, names=cols)
+df2 = df2[df2["rapl_uj_diff"] < 1000000]
+
+fig, ax = plt.subplots()
+plt.tight_layout()
+fig.set_size_inches(5, 3)
+
+ax.plot(df["predicted"], color='blue', label="predicted")
+ax.plot(df["energy"], color='green', label="power reading (j)")
+ax.plot(df["energy"] + df["predicted"], color='red', label="j_predicted + j")
+ax.plot(df2["rapl_uj_diff"] / 1_000_000.0, color='orange', label="rapl_uj_diff")
+
+ax.axhline(args.power_cap, color='black', label="power cap")
+
+# ax.set_title("Energy Cap")
+ax.set_ylabel("Joules")
+# ax.set_xlabel("Time (sec)")
+ax.legend()
+save_fname = os.path.join(os.path.dirname(args.log_file), "predict.png")
+plt.savefig(save_fname, bbox_inches="tight")
+plt.close(fig)


### PR DESCRIPTION
This feature allows Ilúvatar's worker to limit invocations if the system power usage exceeds a configured threshold.
This can monitor either RAPL or IPMI as a power source.

Merge power capping feature into source repo.
Feature is behind compile-time flag so it won't affect performance if not being used.