### PR TITLE
Overwrite net_config_file During Boot to Prevent Stale Bridge Configuration

### DIFF
--- a/src/Ilúvatar/docs/README.md
+++ b/src/Ilúvatar/docs/README.md
@@ -2,7 +2,8 @@
 
 ## Try it out
 
-Easily set up your machine to run Ilúvatar [here](./SETUP.md), then try out [some of](./FUNCTIONS.md) our [examples](./LOAD.md).
+Easily set up your machine to run Ilúvatar [here](./SETUP.md), then try out some of our [examples](examples/README.md).
+Or start running [your own experiments](./LOAD.md) and making [your own functions](./FUNCTIONS.md) to run inside Ilúvatar.
 
 ## Development
 

--- a/src/Ilúvatar/docs/README.md
+++ b/src/Ilúvatar/docs/README.md
@@ -2,8 +2,7 @@
 
 ## Try it out
 
-Easily set up your machine to run Ilúvatar [here](./SETUP.md), then try out some of our [examples](examples/README.md).
-Or start running [your own experiments](./LOAD.md) and making [your own functions](./FUNCTIONS.md) to run inside Ilúvatar.
+Easily set up your machine to run Ilúvatar [here](./SETUP.md), then try out [some of](./FUNCTIONS.md) our [examples](./LOAD.md).
 
 ## Development
 

--- a/src/Ilúvatar/iluvatar_worker_library/src/services/network/namespace_manager.rs
+++ b/src/Ilúvatar/iluvatar_worker_library/src/services/network/namespace_manager.rs
@@ -132,12 +132,9 @@ impl NamespaceManager {
     fn ensure_net_config_file(tid: &TransactionId, config: &Arc<NetworkingConfig>) -> Result<()> {
         let temp_file = utils::file::temp_file_pth("il_worker_br", "conf");
 
-        let mut file = match File::options().read(true).write(true).create_new(true).open(temp_file) {
+        let mut file = match File::create(temp_file){
             Ok(f) => f,
-            Err(e) => match e.kind() {
-                std::io::ErrorKind::AlreadyExists => return Ok(()),
-                _ => anyhow::bail!("[{}] error creating 'il_worker_br' temp file: {}", tid, e),
-            },
+            Err(e) => anyhow::bail!("[{}] error creating 'il_worker_br' temp file: {}", tid, e)
         };
         let bridge_json = include_str!("../../resources/cni/il_worker_br.json")
             .to_string()

--- a/src/Ilúvatar/iluvatar_worker_library/src/services/network/namespace_manager.rs
+++ b/src/Ilúvatar/iluvatar_worker_library/src/services/network/namespace_manager.rs
@@ -132,9 +132,9 @@ impl NamespaceManager {
     fn ensure_net_config_file(tid: &TransactionId, config: &Arc<NetworkingConfig>) -> Result<()> {
         let temp_file = utils::file::temp_file_pth("il_worker_br", "conf");
 
-        let mut file = match File::create(temp_file){
+        let mut file = match File::create(temp_file) {
             Ok(f) => f,
-            Err(e) => anyhow::bail!("[{}] error creating 'il_worker_br' temp file: {}", tid, e)
+            Err(e) => anyhow::bail!("[{}] error creating 'il_worker_br' temp file: {}", tid, e),
         };
         let bridge_json = include_str!("../../resources/cni/il_worker_br.json")
             .to_string()


### PR DESCRIPTION
This pull request addresses an issue where, during the boot process of Iluvatar specifically for containerd isolation, the temporary file "/tmp/iluvatar/il_worker_br.conf" is not overwritten if it already exists. This behavior can lead to the use of stale bridge configurations, potentially causing network issues or unexpected behavior.

